### PR TITLE
Extracted upload tagParams and upload url functionality into their funct...

### DIFF
--- a/cloudinary-core/src/main/java/com/cloudinary/Uploader.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Uploader.java
@@ -297,7 +297,7 @@ public class Uploader {
 	        }
 	    }
 	    
-	    return StringEscapeUtils.escapeHtml(JSONObject.toJSONString(params));
+	    return JSONObject.toJSONString(params);
 	}
 	
 	public String getUploadUrl(Map options) {
@@ -308,7 +308,7 @@ public class Uploader {
 	public String imageUploadTag(String field, Map options, Map<String, Object> htmlOptions) {
         if (htmlOptions == null) htmlOptions = Cloudinary.emptyMap();
 		
-        String tagParams = prepareUploadTagParams(options);
+        String tagParams = StringEscapeUtils.escapeHtml(prepareUploadTagParams(options));
         
 		String cloudinaryUploadUrl = getUploadUrl(options);
         


### PR DESCRIPTION
Hello, I've extracted upload tagParams and upload url functionality into their own functions, this will facilitate frameworks like Angular fetching the server-side params.

The reason for doing this is so I could make a server-side service like:

/cloudinary/requestUploadAuthorization

which returns the signed upload params and upload URL. Then the client side framework (Angular in this case) composes the correct <img> tag and handles all the JS processing.

An alternative would have been for the server-side service to return the fully formed <img> tag, but this seemed less clean in the context of Angular or another framework which composes its own HTML widgets.

In either case, this is a rather harmless change which makes it possible to independently test these portions of the code in the future.
