### PR TITLE
add transformation attribute to cloudinary upload tag

### DIFF
--- a/cloudinary-taglib/src/main/java/com/cloudinary/taglib/CloudinaryUploadTag.java
+++ b/cloudinary-taglib/src/main/java/com/cloudinary/taglib/CloudinaryUploadTag.java
@@ -20,6 +20,7 @@ public class CloudinaryUploadTag extends SimpleTagSupport {
     private String tags = null;
     private String fieldName;
     private String resourceType = "auto";
+    private String transformation;
     
     public void doTag() throws JspException, IOException {
         Cloudinary cloudinary = Singleton.getCloudinary();
@@ -37,6 +38,7 @@ public class CloudinaryUploadTag extends SimpleTagSupport {
         
         Map<String, String> options = new HashMap<String, String>();
         options.put("resource_type", resourceType);
+        options.put("transformation", transformation);
         if (tags != null) {
             options.put("tags", tags);
         }
@@ -84,6 +86,14 @@ public class CloudinaryUploadTag extends SimpleTagSupport {
     
     public String getFieldName() {
         return fieldName;
+    }
+    
+    public void setTransformation(String transformation) {
+        this.transformation = transformation;
+    }
+    
+    public String getTransformation() {
+        return transformation;
     }
 
     public void setResourceType(String resourceType) {

--- a/cloudinary-taglib/src/main/resources/META-INF/cloudinary.tld
+++ b/cloudinary-taglib/src/main/resources/META-INF/cloudinary.tld
@@ -40,6 +40,11 @@
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
+        <attribute>
+            <name>transformation</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
     </tag>
     <tag>
         <name>image</name>


### PR DESCRIPTION
We added a transformation attribute to the cloudinary upload tag so you could set an automatic transformation to apply to all uploaded images
