### PR TITLE
Add Proxy Support

### DIFF
--- a/cloudinary-core/src/main/java/com/cloudinary/Cloudinary.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Cloudinary.java
@@ -175,6 +175,12 @@ public class Cloudinary {
 			}
 		}
 	}
+        
+        
+
+	public Integer getIntegerConfig(String key, Integer default_value) {
+		return asInteger(this.config.get(key), default_value);
+	}
 
 	public boolean getBooleanConfig(String key, boolean default_value) {
 		return asBoolean(this.config.get(key), default_value);
@@ -240,6 +246,16 @@ public class Cloudinary {
 			return (Boolean) value;
 		} else {
 			return "true".equals(value);
+		}
+	}
+
+	public static Integer asInteger(Object value, Integer defaultValue) {
+		if (value == null) {
+			return defaultValue;
+		} else if (value instanceof Integer) {
+			return (Integer) value;
+		} else {
+			return Integer.parseInt(value.toString());
 		}
 	}
 

--- a/cloudinary-core/src/main/java/com/cloudinary/Cloudinary.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Cloudinary.java
@@ -176,8 +176,6 @@ public class Cloudinary {
 		}
 	}
         
-        
-
 	public Integer getIntegerConfig(String key, Integer default_value) {
 		return asInteger(this.config.get(key), default_value);
 	}

--- a/cloudinary-core/src/main/java/com/cloudinary/Uploader.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Uploader.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -27,6 +28,7 @@ import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.params.ConnRoutePNames;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.json.simple.parser.ParseException;
@@ -277,8 +279,14 @@ public class Uploader {
 		}
 
 		String apiUrl = cloudinary.cloudinaryApiUrl(action, options);
-
+                
 		HttpClient client = new DefaultHttpClient(connectionManager);
+                
+                // If the configuration specifies a proxy then apply it to the client
+                if (cloudinary.getStringConfig("proxy_host") != null && cloudinary.getIntegerConfig("proxy_port", null) != null) {
+                    HttpHost proxy = new HttpHost(cloudinary.getStringConfig("proxy_host"), cloudinary.getIntegerConfig("proxy_port", 8080));
+                    client.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+                }
 
 		HttpPost postMethod = new HttpPost(apiUrl);
 		postMethod.setHeader("User-Agent", Cloudinary.USER_AGENT);


### PR DESCRIPTION
Because of the use of various HTTP proxies in commercial environments we needed a way to supply these proxy details to the connection.

The changes mean by constructing the Cloudinary class with a configuration Map you can supply 2 extra attributes:
proxy_host - A String of the IP address or hostname of the proxy
proxy_port - An integer of the port number of the proxy
