### PR TITLE
Pass moderation param in explicit call

### DIFF
--- a/cloudinary-core/src/main/java/com/cloudinary/Uploader.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Uploader.java
@@ -192,6 +192,7 @@ public class Uploader {
         params.put("eager_notification_url", (String) options.get("eager_notification_url"));
         params.put("headers", Util.buildCustomHeaders(options.get("headers")));
         params.put("tags", StringUtils.join(ObjectUtils.asArray(options.get("tags")), ","));
+        params.put("moderation", (String) options.get("moderation"));
         if (options.get("face_coordinates") != null) {
             params.put("face_coordinates", Coordinates.parseCoordinates(options.get("face_coordinates")).toString());
         }

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
@@ -155,7 +155,7 @@ abstract public class AbstractUploaderTest extends MockableTest {
 
     @Test
     public void testExplicit() throws IOException {
-        Map result = cloudinary.uploader().explicit("sample", asMap("eager", Collections.singletonList(new Transformation().crop("scale").width(2.0)), "type", "upload"));
+        Map result = cloudinary.uploader().explicit("sample", asMap("eager", Collections.singletonList(new Transformation().crop("scale").width(2.0)), "type", "upload", "moderation", "manual"));
         String url = cloudinary.url().transformation(new Transformation().crop("scale").width(2.0)).format("jpg").version(result.get("version")).generate("sample");
         String eagerUrl = (String) ((Map) ((List) result.get("eager")).get(0)).get("url");
         String cloudName = cloudinary.config.cloudName;


### PR DESCRIPTION
Allow user to pass `moderation` parameter when performing an `explicit` call (useful for queueing a second moderation after already having performed a different moderation in the `upload` call).