### PR TITLE
Close responsestream

### DIFF
--- a/cloudinary-android/src/main/java/com/cloudinary/android/UploaderStrategy.java
+++ b/cloudinary-android/src/main/java/com/cloudinary/android/UploaderStrategy.java
@@ -115,6 +115,10 @@ public class UploaderStrategy extends AbstractUploaderStrategy {
         String responseData = readFully(responseStream);
         connection.disconnect();
 
+        try {
+            responseStream.close();
+        } catch (Exception e) {}
+
         if (code != 200 && code != 400 && code != 404 && code != 500) {
             throw new RuntimeException("Server returned unexpected status code - " + code + " - " + responseData);
         }


### PR DESCRIPTION
Avoids memory leak

```
E/StrictMode: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
                                                                                  java.lang.Throwable: Explicit termination method 'end' not called
java.lang.Throwable: Explicit termination method 'end' not called
  at dalvik.system.CloseGuard.open(CloseGuard.java:180)
  at java.util.zip.Inflater.<init>(Inflater.java:104)
  at com.android.okhttp.okio.GzipSource.<init>(GzipSource.java:62)
  at com.android.okhttp.internal.http.HttpEngine.unzip(HttpEngine.java:645)
  at com.android.okhttp.internal.http.HttpEngine.readResponse(HttpEngine.java:821)
  at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:463)
  at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:405)
  at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponseCode(HttpURLConnectionImpl.java:521)
  at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getResponseCode(DelegatingHttpsURLConnection.java:105)
  at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java)
  at com.cloudinary.android.UploaderStrategy.callApi(UploaderStrategy.java:105)
  at com.cloudinary.Uploader.callApi(Uploader.java:34)
  at com.cloudinary.Uploader.upload(Uploader.java:76)
  at com.cloudinary.Uploader.upload(Uploader.java:68)
  at com.crewapp.android.crew.data.MediaUploader$2.run(MediaUploader.java:192)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
  at java.lang.Thread.run(Thread.java:761)
```