### PR TITLE
Change url suffix and root path limitations

### DIFF
--- a/cloudinary-core/src/main/java/com/cloudinary/Url.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Url.java
@@ -328,15 +328,6 @@ public class Url {
             throw new IllegalArgumentException("Must supply cloud_name in tag or in configuration");
         }
 
-        if (!this.config.privateCdn) {
-            if (StringUtils.isNotBlank(urlSuffix)) {
-                throw new IllegalArgumentException("URL Suffix only supported in private CDN");
-            }
-            if (useRootPath) {
-                throw new IllegalArgumentException("Root path only supported in private CDN");
-            }
-        }
-
         if (source == null) {
             if (publicId == null) {
                 if (this.source == null) {
@@ -457,11 +448,17 @@ public class Url {
             } else if (resourceType.equals("image") && type.equals("private")) {
                 resourceType = "private_images";
                 type = null;
+            } else if (resourceType.equals("image") && type.equals("authenticated")){
+                resourceType = "authenticated_images";
+                type = null;
             } else if (resourceType.equals("raw") && type.equals("upload")) {
                 resourceType = "files";
                 type = null;
+            } else if (resourceType.equals("video") && type.equals("upload")){
+                resourceType = "videos";
+                type = null;
             } else {
-                throw new IllegalArgumentException("URL Suffix only supported for image/upload, image/private and raw/upload");
+                throw new IllegalArgumentException("URL Suffix only supported for image/upload, image/private, raw/upload, image/authenticated  and video/upload");
             }
         }
         if (useRootPath) {

--- a/cloudinary-core/src/test/java/com/cloudinary/test/CloudinaryTest.java
+++ b/cloudinary-core/src/test/java/com/cloudinary/test/CloudinaryTest.java
@@ -164,11 +164,6 @@ public class CloudinaryTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testDisallowUrlSuffixInSharedDistribution() {
-        cloudinary.url().suffix("hello").generate("test");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
     public void testDisallowUrlSuffixInNonUploadTypes() {
         cloudinary.url().suffix("hello").privateCdn(true).type("facebook").generate("test");
 
@@ -229,13 +224,21 @@ public class CloudinaryTest {
     }
 
     @Test
+    public void testSupportUrlSuffixForVideoUploads() {
+        String actual = cloudinary.url().suffix("hello").privateCdn(true).resourceType("video").generate("test");
+        assertEquals("http://test123-res.cloudinary.com/videos/test/hello", actual);
+    }
+
+    @Test
+    public void testSupportUrlSuffixForAuthenticatedImages() {
+        String actual = cloudinary.url().suffix("hello").privateCdn(true).resourceType("image").type("authenticated").generate("test");
+        assertEquals("http://test123-res.cloudinary.com/authenticated_images/test/hello", actual);
+    }
+
+    @Test
     public void testSupportUrlSuffixForPrivateImages(){
         String actual = cloudinary.url().suffix("hello").privateCdn(true).resourceType("image").type("private").generate("test");
         assertEquals("http://test123-res.cloudinary.com/private_images/test/hello", actual);
-    }
-    @Test(expected = IllegalArgumentException.class)
-    public void testDisllowUseRootPathInSharedDistribution() {
-        cloudinary.url().useRootPath(true).generate("test");
     }
 
     @Test


### PR DESCRIPTION
* Allow rootPath/urlSuffix without a private cdn.
* Allow rootPath/urlSuffix for videos.
* Allow rootPath/urlSuffix for authenticated images.