### PR TITLE
Allow support for `urls` parameter for `generateSprite()` and `multi()`

### DIFF
--- a/cloudinary-core/src/main/java/com/cloudinary/Cloudinary.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Cloudinary.java
@@ -8,10 +8,13 @@ import com.cloudinary.strategies.StrategyLoader;
 import com.cloudinary.utils.ObjectUtils;
 import com.cloudinary.utils.StringUtils;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.security.SecureRandom;
 import java.util.*;
+
+import static com.cloudinary.Util.buildMultiParams;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class Cloudinary {
@@ -224,6 +227,51 @@ public class Cloudinary {
         return downloadArchive(options, "zip");
     }
 
+    public String downloadGeneratedSprite(String tag, Map options) throws IOException {
+        if (options == null)
+            options = new HashMap();
+
+        options.put("tag", tag);
+        options.put("mode", ArchiveParams.MODE_DOWNLOAD);
+
+        Map params = Util.buildGenerateSpriteParams(options);
+        signRequest(params, options);
+
+        return buildUrl(cloudinaryApiUrl("sprite", options), params);
+    }
+
+    public String downloadGeneratedSprite(String[] urls, Map options) throws IOException {
+        if (options == null)
+            options = new HashMap();
+
+        options.put("urls", urls);
+        options.put("mode", ArchiveParams.MODE_DOWNLOAD);
+
+        Map params = Util.buildGenerateSpriteParams(options);
+        signRequest(params, options);
+
+        return buildUrl(cloudinaryApiUrl("sprite", options), params);
+    }
+
+    public String downloadMulti(String tag, Map options) throws IOException {
+        if (options == null)
+            options = new HashMap();
+
+        options.put("tag", tag);
+        options.put("mode", ArchiveParams.MODE_DOWNLOAD);
+
+        return buildUrl(cloudinaryApiUrl("multi", options), buildMultiParams(options));
+    }
+
+    public String downloadMulti(String[] urls, Map options) throws IOException {
+        if (options == null)
+            options = new HashMap();
+
+        options.put("urls", urls);
+        options.put("mode", ArchiveParams.MODE_DOWNLOAD);
+
+        return buildUrl(cloudinaryApiUrl("multi", options), buildMultiParams(options));
+    }
 
     private String buildUrl(String base, Map<String, Object> params) throws UnsupportedEncodingException {
         StringBuilder urlBuilder = new StringBuilder();
@@ -233,6 +281,8 @@ public class Cloudinary {
         }
         boolean first = true;
         for (Map.Entry<String, Object> param : params.entrySet()) {
+            if (param.getValue() == null) continue;
+
             String keyValue = null;
             Object value = param.getValue();
             if (!first) urlBuilder.append("&");

--- a/cloudinary-core/src/main/java/com/cloudinary/Cloudinary.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Cloudinary.java
@@ -228,6 +228,8 @@ public class Cloudinary {
     }
 
     public String downloadGeneratedSprite(String tag, Map options) throws IOException {
+        if (StringUtils.isEmpty(tag)) throw new IllegalArgumentException("Tag cannot be empty");
+
         if (options == null)
             options = new HashMap();
 
@@ -241,6 +243,7 @@ public class Cloudinary {
     }
 
     public String downloadGeneratedSprite(String[] urls, Map options) throws IOException {
+        if (urls.length < 1) throw new IllegalArgumentException("Request must contain at least one URL.");
         if (options == null)
             options = new HashMap();
 
@@ -254,23 +257,31 @@ public class Cloudinary {
     }
 
     public String downloadMulti(String tag, Map options) throws IOException {
+        if (StringUtils.isEmpty(tag)) throw new IllegalArgumentException("Tag cannot be empty");
         if (options == null)
             options = new HashMap();
 
         options.put("tag", tag);
         options.put("mode", ArchiveParams.MODE_DOWNLOAD);
 
-        return buildUrl(cloudinaryApiUrl("multi", options), buildMultiParams(options));
+        Map params = buildMultiParams(options);
+        signRequest(params, options);
+
+        return buildUrl(cloudinaryApiUrl("multi", options), params);
     }
 
     public String downloadMulti(String[] urls, Map options) throws IOException {
+        if (urls.length < 1) throw new IllegalArgumentException("Request must contain at least one URL.");
         if (options == null)
             options = new HashMap();
 
         options.put("urls", urls);
         options.put("mode", ArchiveParams.MODE_DOWNLOAD);
 
-        return buildUrl(cloudinaryApiUrl("multi", options), buildMultiParams(options));
+        Map params = buildMultiParams(options);
+        signRequest(params, options);
+
+        return buildUrl(cloudinaryApiUrl("multi", options), params);
     }
 
     private String buildUrl(String base, Map<String, Object> params) throws UnsupportedEncodingException {

--- a/cloudinary-core/src/main/java/com/cloudinary/Uploader.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Uploader.java
@@ -265,9 +265,19 @@ public class Uploader {
     }
 
     public Map generateSprite(String tag, Map options) throws IOException {
+        options.put("tag", tag);
+        return generateSprite(options);
+    }
+
+    public Map generateSprite(String[] urls, Map options) throws IOException {
+        options.put("urls", urls);
+        return generateSprite(options);
+    }
+
+    private Map generateSprite(Map options) throws IOException {
         if (options == null)
             options = ObjectUtils.emptyMap();
-        Map<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<String, Object>();
         Object transParam = options.get("transformation");
         Transformation transformation = null;
         if (transParam instanceof Transformation) {
@@ -282,13 +292,28 @@ public class Uploader {
             transformation.fetchFormat(format);
         }
         params.put("transformation", transformation.generate());
-        params.put("tag", tag);
+        params.put("tag", options.get("tag"));
+        if (options.containsKey("urls")) {
+            params.put("urls", Arrays.asList((String[]) options.get("urls")));
+        }
         params.put("notification_url", (String) options.get("notification_url"));
         params.put("async", ObjectUtils.asBoolean(options.get("async"), false).toString());
+        params.put("mode", options.get("mode"));
+
         return callApi("sprite", params, options, null);
     }
 
+    public Map multi(String[] urls, Map options) throws IOException {
+        options.put("urls", urls);
+        return multi(options);
+    }
+
     public Map multi(String tag, Map options) throws IOException {
+       options.put("tag", tag);
+       return multi(options);
+    }
+
+    private Map multi(Map options) throws IOException {
         if (options == null)
             options = ObjectUtils.emptyMap();
         Map<String, Object> params = new HashMap<String, Object>();
@@ -299,10 +324,14 @@ public class Uploader {
             }
             params.put("transformation", transformation.toString());
         }
-        params.put("tag", tag);
+        params.put("tag", options.get("tag"));
+        if (options.containsKey("urls")) {
+            params.put("urls", Arrays.asList((String[]) options.get("urls")));
+        }
         params.put("notification_url", (String) options.get("notification_url"));
         params.put("format", (String) options.get("format"));
         params.put("async", ObjectUtils.asBoolean(options.get("async"), false).toString());
+
         return callApi("multi", params, options, null);
     }
 

--- a/cloudinary-core/src/main/java/com/cloudinary/Uploader.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Uploader.java
@@ -6,10 +6,10 @@ import com.cloudinary.utils.StringUtils;
 import org.cloudinary.json.JSONObject;
 
 import java.io.*;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
+
+import static com.cloudinary.Util.buildGenerateSpriteParams;
+import static com.cloudinary.Util.buildMultiParams;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class Uploader {
@@ -265,74 +265,45 @@ public class Uploader {
     }
 
     public Map generateSprite(String tag, Map options) throws IOException {
-        options.put("tag", tag);
-        return generateSprite(options);
+        if (options == null)
+            options = Collections.singletonMap("tag", tag);
+        else
+            options.put("tag", tag);
+
+        return callApi("sprite", buildGenerateSpriteParams(options), options, null);
     }
 
     public Map generateSprite(String[] urls, Map options) throws IOException {
-        options.put("urls", urls);
-        return generateSprite(options);
-    }
-
-    private Map generateSprite(Map options) throws IOException {
         if (options == null)
-            options = ObjectUtils.emptyMap();
-        HashMap<String, Object> params = new HashMap<String, Object>();
-        Object transParam = options.get("transformation");
-        Transformation transformation = null;
-        if (transParam instanceof Transformation) {
-            transformation = new Transformation((Transformation) transParam);
-        } else if (transParam instanceof String) {
-            transformation = new Transformation().rawTransformation((String) transParam);
-        } else {
-            transformation = new Transformation();
-        }
-        String format = (String) options.get("format");
-        if (format != null) {
-            transformation.fetchFormat(format);
-        }
-        params.put("transformation", transformation.generate());
-        params.put("tag", options.get("tag"));
-        if (options.containsKey("urls")) {
-            params.put("urls", Arrays.asList((String[]) options.get("urls")));
-        }
-        params.put("notification_url", (String) options.get("notification_url"));
-        params.put("async", ObjectUtils.asBoolean(options.get("async"), false).toString());
-        params.put("mode", options.get("mode"));
+            options = Collections.singletonMap("urls", urls);
+        else
+            options.put("urls", urls);
 
-        return callApi("sprite", params, options, null);
+        return callApi("sprite", buildGenerateSpriteParams(options), options, null);
     }
 
     public Map multi(String[] urls, Map options) throws IOException {
-        options.put("urls", urls);
+        if (options == null) {
+            options = Collections.singletonMap("urls", urls);
+        } else {
+            options.put("urls", urls);
+        }
+
         return multi(options);
     }
 
     public Map multi(String tag, Map options) throws IOException {
-       options.put("tag", tag);
-       return multi(options);
+        if (options == null) {
+            options = Collections.singletonMap("tag", tag);
+        } else {
+            options.put("tag", tag);
+        }
+
+        return multi(options);
     }
 
     private Map multi(Map options) throws IOException {
-        if (options == null)
-            options = ObjectUtils.emptyMap();
-        Map<String, Object> params = new HashMap<String, Object>();
-        Object transformation = options.get("transformation");
-        if (transformation != null) {
-            if (transformation instanceof Transformation) {
-                transformation = ((Transformation) transformation).generate();
-            }
-            params.put("transformation", transformation.toString());
-        }
-        params.put("tag", options.get("tag"));
-        if (options.containsKey("urls")) {
-            params.put("urls", Arrays.asList((String[]) options.get("urls")));
-        }
-        params.put("notification_url", (String) options.get("notification_url"));
-        params.put("format", (String) options.get("format"));
-        params.put("async", ObjectUtils.asBoolean(options.get("async"), false).toString());
-
-        return callApi("multi", params, options, null);
+        return callApi("multi", buildMultiParams(options), options, null);
     }
 
     public Map explode(String public_id, Map options) throws IOException {

--- a/cloudinary-core/src/main/java/com/cloudinary/Util.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Util.java
@@ -87,6 +87,7 @@ public class Util {
         params.put("format", (String) options.get("format"));
         params.put("async", ObjectUtils.asBoolean(options.get("async"), false).toString());
         params.put("mode", options.get("mode"));
+        putObject("timestamp", options, params, Util.timestamp());
 
         return params;
     }
@@ -114,6 +115,7 @@ public class Util {
         params.put("notification_url", (String) options.get("notification_url"));
         params.put("async", ObjectUtils.asBoolean(options.get("async"), false).toString());
         params.put("mode", options.get("mode"));
+        putObject("timestamp", options, params, Util.timestamp());
 
         return params;
     }

--- a/cloudinary-core/src/main/java/com/cloudinary/Util.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Util.java
@@ -69,6 +69,55 @@ public class Util {
         return params;
     }
 
+    public static Map buildMultiParams(Map options) {
+        Map<String, Object> params = new HashMap<String, Object>();
+
+        Object transformation = options.get("transformation");
+        if (transformation != null) {
+            if (transformation instanceof Transformation) {
+                transformation = ((Transformation) transformation).generate();
+            }
+            params.put("transformation", transformation.toString());
+        }
+        params.put("tag", options.get("tag"));
+        if (options.containsKey("urls")) {
+            params.put("urls", Arrays.asList((String[]) options.get("urls")));
+        }
+        params.put("notification_url", (String) options.get("notification_url"));
+        params.put("format", (String) options.get("format"));
+        params.put("async", ObjectUtils.asBoolean(options.get("async"), false).toString());
+        params.put("mode", options.get("mode"));
+
+        return params;
+    }
+
+    public static Map<String, Object> buildGenerateSpriteParams(Map options) {
+        HashMap<String, Object> params = new HashMap<String, Object>();
+        Object transParam = options.get("transformation");
+        Transformation transformation = null;
+        if (transParam instanceof Transformation) {
+            transformation = new Transformation((Transformation) transParam);
+        } else if (transParam instanceof String) {
+            transformation = new Transformation().rawTransformation((String) transParam);
+        } else {
+            transformation = new Transformation();
+        }
+        String format = (String) options.get("format");
+        if (format != null) {
+            transformation.fetchFormat(format);
+        }
+        params.put("transformation", transformation.generate());
+        params.put("tag", options.get("tag"));
+        if (options.containsKey("urls")) {
+            params.put("urls", Arrays.asList((String[]) options.get("urls")));
+        }
+        params.put("notification_url", (String) options.get("notification_url"));
+        params.put("async", ObjectUtils.asBoolean(options.get("async"), false).toString());
+        params.put("mode", options.get("mode"));
+
+        return params;
+    }
+
     protected static final String buildEager(List<? extends Transformation> transformations) {
         if (transformations == null) {
             return null;

--- a/cloudinary-core/src/test/java/com/cloudinary/test/CloudinaryTest.java
+++ b/cloudinary-core/src/test/java/com/cloudinary/test/CloudinaryTest.java
@@ -655,33 +655,52 @@ public class CloudinaryTest {
     @Test
     public void testDownloadSprite() throws Exception{
         final String spriteTestTag = "sprite_tag";
-        final String url1 = "https://www.res.cloudinary.com/demo/image/upload/sample";
-        final String url2 = "https://www.res.cloudinary.com/demo/image/upload/car";
+        final String url1 = "https://res.cloudinary.com/demo/image/upload/sample";
+        final String url2 = "https://res.cloudinary.com/demo/image/upload/car";
 
         String urlFromTag = cloudinary.downloadGeneratedSprite(spriteTestTag, null);
         String urlFromUrls = cloudinary.downloadGeneratedSprite(new String[]{url1, url2}, null);
 
         assertTrue(urlFromTag.startsWith("https://api.cloudinary.com/v1_1/" + cloudinary.config.cloudName + "/image/sprite?mode=download"));
         assertTrue(urlFromUrls.startsWith("https://api.cloudinary.com/v1_1/" + cloudinary.config.cloudName + "/image/sprite?mode=download"));
-        assertTrue(urlFromTag.contains("tag=" + spriteTestTag));
         assertTrue(urlFromUrls.contains("urls[]=" + URLEncoder.encode(url1, "UTF-8")));
         assertTrue(urlFromUrls.contains("urls[]=" + URLEncoder.encode(url2, "UTF-8")));
+
+        Map<String, String> parameters = getUrlParameters(new URI(urlFromTag));
+        assertEquals(spriteTestTag, parameters.get("tag"));
+        assertNotNull(parameters.get("timestamp"));
+        assertNotNull(parameters.get("signature"));
+
+        parameters = getUrlParameters(new URI(urlFromUrls));
+        assertNotNull(parameters.get("timestamp"));
+        assertNotNull(parameters.get("signature"));
     }
 
     @Test
     public void testDownloadMulti() throws Exception{
+        cloudinary = new Cloudinary("cloudinary://571927874334573:yABWqlfSV2d5pRW4ujHJYA7SD34@nitzanj?load_strategies=false");
+
         final String multiTestTag = "multi_test_tag";
-        final String url1 = "https://www.res.cloudinary.com/demo/image/upload/sample";
-        final String url2 = "https://www.res.cloudinary.com/demo/image/upload/car";
+        final String url1 = "https://res.cloudinary.com/demo/image/upload/sample";
+        final String url2 = "https://res.cloudinary.com/demo/image/upload/car";
 
         String urlFromTag = cloudinary.downloadMulti(multiTestTag, null);
         String urlFromUrls = cloudinary.downloadMulti(new String[]{url1, url2}, null);
 
         assertTrue(urlFromTag.startsWith("https://api.cloudinary.com/v1_1/" + cloudinary.config.cloudName + "/image/multi?mode=download"));
         assertTrue(urlFromUrls.startsWith("https://api.cloudinary.com/v1_1/" + cloudinary.config.cloudName + "/image/multi?mode=download"));
-        assertTrue(urlFromTag.contains("tag=" + multiTestTag));
         assertTrue(urlFromUrls.contains("urls[]=" + URLEncoder.encode(url1, "UTF-8")));
         assertTrue(urlFromUrls.contains("urls[]=" + URLEncoder.encode(url2, "UTF-8")));
+
+        Map<String, String> parameters = getUrlParameters(new URI(urlFromTag));
+        assertEquals(multiTestTag, parameters.get("tag"));
+        assertNotNull(parameters.get("timestamp"));
+        assertNotNull(parameters.get("signature"));
+
+        parameters = getUrlParameters(new URI(urlFromUrls));
+        assertNotNull(parameters.get("timestamp"));
+        assertNotNull(parameters.get("signature"));
+
     }
     @Test
     public void testSpriteCss() {

--- a/cloudinary-core/src/test/java/com/cloudinary/test/CloudinaryTest.java
+++ b/cloudinary-core/src/test/java/com/cloudinary/test/CloudinaryTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -651,6 +652,37 @@ public class CloudinaryTest {
         assertEquals("/v1_1/test123/image/download_tag.zip", uri.getPath());
     }
 
+    @Test
+    public void testDownloadSprite() throws Exception{
+        final String spriteTestTag = "sprite_tag";
+        final String url1 = "https://www.res.cloudinary.com/demo/image/upload/sample";
+        final String url2 = "https://www.res.cloudinary.com/demo/image/upload/car";
+
+        String urlFromTag = cloudinary.downloadGeneratedSprite(spriteTestTag, null);
+        String urlFromUrls = cloudinary.downloadGeneratedSprite(new String[]{url1, url2}, null);
+
+        assertTrue(urlFromTag.startsWith("https://api.cloudinary.com/v1_1/" + cloudinary.config.cloudName + "/image/sprite?mode=download"));
+        assertTrue(urlFromUrls.startsWith("https://api.cloudinary.com/v1_1/" + cloudinary.config.cloudName + "/image/sprite?mode=download"));
+        assertTrue(urlFromTag.contains("tag=" + spriteTestTag));
+        assertTrue(urlFromUrls.contains("urls[]=" + URLEncoder.encode(url1, "UTF-8")));
+        assertTrue(urlFromUrls.contains("urls[]=" + URLEncoder.encode(url2, "UTF-8")));
+    }
+
+    @Test
+    public void testDownloadMulti() throws Exception{
+        final String multiTestTag = "multi_test_tag";
+        final String url1 = "https://www.res.cloudinary.com/demo/image/upload/sample";
+        final String url2 = "https://www.res.cloudinary.com/demo/image/upload/car";
+
+        String urlFromTag = cloudinary.downloadMulti(multiTestTag, null);
+        String urlFromUrls = cloudinary.downloadMulti(new String[]{url1, url2}, null);
+
+        assertTrue(urlFromTag.startsWith("https://api.cloudinary.com/v1_1/" + cloudinary.config.cloudName + "/image/multi?mode=download"));
+        assertTrue(urlFromUrls.startsWith("https://api.cloudinary.com/v1_1/" + cloudinary.config.cloudName + "/image/multi?mode=download"));
+        assertTrue(urlFromTag.contains("tag=" + multiTestTag));
+        assertTrue(urlFromUrls.contains("urls[]=" + URLEncoder.encode(url1, "UTF-8")));
+        assertTrue(urlFromUrls.contains("urls[]=" + URLEncoder.encode(url2, "UTF-8")));
+    }
     @Test
     public void testSpriteCss() {
         String result = cloudinary.url().generateSpriteCss("test");

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
@@ -268,13 +268,19 @@ abstract public class AbstractUploaderTest extends MockableTest {
         assertTrue(tag.contains("class='cloudinary-fileupload myclass'"));
     }
 
-
     @Test
     public void testSprite() throws Exception {
         final String sprite_test_tag = String.format("sprite_test_tag_%d", new java.util.Date().getTime());
-        cloudinary.uploader().upload(SRC_TEST_IMAGE, asMap("tags", new String[]{sprite_test_tag, SDK_TEST_TAG, UPLOADER_TAG}, "public_id", "sprite_test_tag_1" + SUFFIX));
-        cloudinary.uploader().upload(SRC_TEST_IMAGE, asMap("tags", new String[]{sprite_test_tag, SDK_TEST_TAG, UPLOADER_TAG}, "public_id", "sprite_test_tag_2" + SUFFIX));
-        Map result = cloudinary.uploader().generateSprite(sprite_test_tag, asMap("tags", Arrays.asList(SDK_TEST_TAG, UPLOADER_TAG)));
+        Map uploadResult1 = cloudinary.uploader().upload(SRC_TEST_IMAGE, asMap("tags", new String[]{sprite_test_tag, SDK_TEST_TAG, UPLOADER_TAG}, "public_id", "sprite_test_tag_1" + SUFFIX));
+        Map uploadResult2 = cloudinary.uploader().upload(SRC_TEST_IMAGE, asMap("tags", new String[]{sprite_test_tag, SDK_TEST_TAG, UPLOADER_TAG}, "public_id", "sprite_test_tag_2" + SUFFIX));
+
+        String[] urls = new String[]{uploadResult1.get("url").toString(), uploadResult2.get("url").toString()};
+
+        Map result = cloudinary.uploader().generateSprite(urls, asMap("tags", Arrays.asList(SDK_TEST_TAG, UPLOADER_TAG)));
+        addToDeleteList("sprite", result.get("public_id").toString());
+        assertEquals(2, ((Map) result.get("image_infos")).size());
+
+        result = cloudinary.uploader().generateSprite(sprite_test_tag, asMap("tags", Arrays.asList(SDK_TEST_TAG, UPLOADER_TAG)));
         addToDeleteList("sprite", result.get("public_id").toString());
         assertEquals(2, ((Map) result.get("image_infos")).size());
         result = cloudinary.uploader().generateSprite(sprite_test_tag, asMap("transformation", "w_100"));
@@ -289,10 +295,19 @@ abstract public class AbstractUploaderTest extends MockableTest {
     public void testMulti() throws Exception {
         final String MULTI_TEST_TAG = "multi_test_tag" + SUFFIX;
         final Map options = asMap("tags", new String[]{MULTI_TEST_TAG, SDK_TEST_TAG, UPLOADER_TAG});
-        cloudinary.uploader().upload(SRC_TEST_IMAGE, options);
-        cloudinary.uploader().upload(SRC_TEST_IMAGE, options);
+        Map uploadResult1 = cloudinary.uploader().upload(SRC_TEST_IMAGE, options);
+        Map uploadResult2 = cloudinary.uploader().upload(SRC_TEST_IMAGE, options);
+
+        String[] urls = new String[]{uploadResult1.get("url").toString(), uploadResult2.get("url").toString()};
+
+        Map result = cloudinary.uploader().multi(urls, asMap("transformation", "c_crop,w_0.5"));
+        addToDeleteList("multi", result.get("public_id").toString());
+
+        assertTrue(((String) result.get("url")).endsWith(".gif"));
+        assertTrue(((String) result.get("url")).contains("w_0.5"));
+
         List<String> ids = new ArrayList<String>();
-        Map result = cloudinary.uploader().multi(MULTI_TEST_TAG, asMap("transformation", "c_crop,w_0.5"));
+        result = cloudinary.uploader().multi(MULTI_TEST_TAG, asMap("transformation", "c_crop,w_0.5"));
         addToDeleteList("multi", result.get("public_id").toString());
         Map pdfResult = cloudinary.uploader().multi(MULTI_TEST_TAG, asMap("transformation", new Transformation().width(111), "format", "pdf"));
         addToDeleteList("multi", pdfResult.get("public_id").toString());

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
@@ -12,13 +12,13 @@ import org.junit.rules.TestName;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.zip.ZipInputStream;
 
-import static com.cloudinary.utils.ObjectUtils.asArray;
-import static com.cloudinary.utils.ObjectUtils.asMap;
+import static com.cloudinary.utils.ObjectUtils.*;
 import static com.cloudinary.utils.StringUtils.isRemoteUrl;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
@@ -255,7 +255,6 @@ abstract public class AbstractUploaderTest extends MockableTest {
         assertTrue(((Integer) result.get("width")) > 1);
         assertTrue(((Integer) result.get("height")) > 1);
     }
-
 
     @Test
     public void testImageUploadTag() {


### PR DESCRIPTION
This PR adds support for a new parameter called `urls` in two `Uploader` methods: `multi()` and `generateSprite()`.

Both are aggregate methods - they need a set of assets to work on. Until now this set was defined by a `tag` parameter, and now support for a list of urls was added.

Note: you can't omit both 'urls` and 'tag` - one is required.

The second feature added in this PR is the ability to generate a download-url for a sprite or a multi request.