### PR TITLE
Changed the version checking in the URL

### DIFF
--- a/cloudinary-core/src/main/java/com/cloudinary/Url.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Url.java
@@ -377,7 +377,7 @@ public class Url {
         source = finalizedSource[0];
         String sourceToSign = finalizedSource[1];
 
-        if (this.config.forceVersion && sourceToSign.contains("/") && !StringUtils.hasVersionString(sourceToSign) &&
+        if (this.config.forceVersion && sourceToSign.contains("/") && !StringUtils.startWithVersionString(sourceToSign) &&
                 !httpSource && StringUtils.isEmpty(version)) {
             version = "1";
         }

--- a/cloudinary-core/src/main/java/com/cloudinary/utils/StringUtils.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/utils/StringUtils.java
@@ -340,26 +340,15 @@ public class StringUtils {
     }
 
     /**
-     * Checks whether the url contains a versioning string (v + number, e.g. v12345)
-     * @param url The url to check
-     * @return Whether a version string is contained within the url
+     * Checks whether a publicId starts a versioning string (v + number, e.g. v12345)
+     * @param publicId The url to check
+     * @return Whether a version string is contained within the publicId
      */
-    public static boolean hasVersionString(String url) {
-        boolean inVersion = false;
-        for (int i = 0; i < url.length(); i++) {
-            char c = url.charAt(i);
-            if (c == 'v') {
-                inVersion = true;
-            } else if (Character.isDigit(c) && inVersion) {
-                return true;
-            } else {
-                inVersion = false;
-            }
-
-
+    public static boolean startWithVersionString(String publicId){
+        if (publicId.startsWith("/")){
+            publicId = publicId.substring(1);
         }
-
-        return false;
+        return publicId.length()>1 && publicId.startsWith("v") && Character.isDigit(publicId.charAt(1));
     }
 
     /**

--- a/cloudinary-core/src/test/java/com/cloudinary/UtilTest.java
+++ b/cloudinary-core/src/test/java/com/cloudinary/UtilTest.java
@@ -129,18 +129,27 @@ public class UtilTest {
     }
 
     @Test
-    public void testHasVersionString(){
-        assertTrue(StringUtils.hasVersionString("wqeasdlv31423423"));
-        assertTrue(StringUtils.hasVersionString("v1"));
-        assertTrue(StringUtils.hasVersionString("v1fdasfasd"));
-        assertTrue(StringUtils.hasVersionString("asdasv1fdasfasd"));
-        assertTrue(StringUtils.hasVersionString("12v1fdasfasd"));
+    public void testStartWithVersionString(){
+        assertTrue(StringUtils.startWithVersionString("v1"));
+        assertTrue(StringUtils.startWithVersionString("v1fdasfasd"));
+        assertTrue(StringUtils.startWithVersionString("v112fdasfasd"));
+        assertTrue(StringUtils.startWithVersionString("v112/fda/sfasd"));
+        assertTrue(StringUtils.startWithVersionString("v112/fda/v1sfasd"));
+        assertTrue(StringUtils.startWithVersionString("/v112/fda/v1sfasd"));
 
-        assertFalse(StringUtils.hasVersionString("121fdasfasd"));
-        assertFalse(StringUtils.hasVersionString(""));
-        assertFalse(StringUtils.hasVersionString("vvv"));
-        assertFalse(StringUtils.hasVersionString("v"));
-        assertFalse(StringUtils.hasVersionString("asdvvv"));
+        assertFalse(StringUtils.startWithVersionString("asdasv1fdasfasd"));
+        assertFalse(StringUtils.startWithVersionString("12v1fdasfasd"));
+        assertFalse(StringUtils.startWithVersionString("asdasv1fdasfasd"));
+        assertFalse(StringUtils.startWithVersionString("wqeasdlv31423423"));
+        assertFalse(StringUtils.startWithVersionString("wqeasdl/v31423423"));
+        assertFalse(StringUtils.startWithVersionString("121fdasfasd"));
+        assertFalse(StringUtils.startWithVersionString("/121fdasfasd"));
+        assertFalse(StringUtils.startWithVersionString("/"));
+        assertFalse(StringUtils.startWithVersionString("/v"));
+        assertFalse(StringUtils.startWithVersionString(""));
+        assertFalse(StringUtils.startWithVersionString("vvv"));
+        assertFalse(StringUtils.startWithVersionString("v"));
+        assertFalse(StringUtils.startWithVersionString("asdvvv"));
     }
 
     @Test

--- a/cloudinary-core/src/test/java/com/cloudinary/test/CloudinaryTest.java
+++ b/cloudinary-core/src/test/java/com/cloudinary/test/CloudinaryTest.java
@@ -636,6 +636,14 @@ public class CloudinaryTest {
         result = cloudinary.url().generate("folder/test");
         assertEquals(DEFAULT_UPLOAD_PATH + "v1/folder/test", result);
 
+        // should not add version if the path STARTS with 'v[num]'
+        result = cloudinary.url().generate("v1234/folder/test");
+        assertEquals(DEFAULT_UPLOAD_PATH + "v1234/folder/test", result);
+
+        // should add version if the path CONTAINS 'v[num]'
+        result = cloudinary.url().generate("folder/v123test");
+        assertEquals(DEFAULT_UPLOAD_PATH + "v1/folder/v123test", result);
+
         // should add version if forceVersion is true
         result = cloudinary.url().forceVersion(true).generate("folder/test");
         assertEquals(DEFAULT_UPLOAD_PATH + "v1/folder/test", result);

--- a/java_shared.gradle
+++ b/java_shared.gradle
@@ -1,5 +1,5 @@
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 javadoc {
     options.encoding = 'UTF-8'


### PR DESCRIPTION
The check whether we should add a version or not used the method `hasVersionString` which checks if it contains 'v[num]' anywhere in the string. 
I changed to check `startWithVersionString` and now it skips the version adding, only if the publicId STARTS with 'v[num]'