### PR TITLE
Disables provisioning tests if environment variable is not set

### DIFF
--- a/cloudinary-http42/build.gradle
+++ b/cloudinary-http42/build.gradle
@@ -11,6 +11,9 @@ apply from: "../java_shared.gradle"
 task ciTest( type: Test ) {
     useJUnit {
         excludeCategories 'com.cloudinary.test.TimeoutTest'
+        if (System.getProperty("CLOUDINARY_ACCOUNT_URL") == "") {
+            exclude '**/AccountApiTest.class'
+        }
     }
 }
 

--- a/cloudinary-http43/build.gradle
+++ b/cloudinary-http43/build.gradle
@@ -11,6 +11,9 @@ apply from: "../java_shared.gradle"
 task ciTest( type: Test ) {
     useJUnit {
         excludeCategories 'com.cloudinary.test.TimeoutTest'
+        if (System.getProperty("CLOUDINARY_ACCOUNT_URL") == "") {
+            exclude '**/AccountApiTest.class'
+        }
     }
 }
 

--- a/cloudinary-http44/build.gradle
+++ b/cloudinary-http44/build.gradle
@@ -11,6 +11,9 @@ apply from: "../java_shared.gradle"
 task ciTest( type: Test ) {
     useJUnit {
         excludeCategories 'com.cloudinary.test.TimeoutTest'
+        if (System.getProperty("CLOUDINARY_ACCOUNT_URL") == "") {
+            exclude '**/AccountApiTest.class'
+        }
     }
 }
 

--- a/cloudinary-http45/build.gradle
+++ b/cloudinary-http45/build.gradle
@@ -11,6 +11,9 @@ apply from: "../java_shared.gradle"
 task ciTest( type: Test ) {
     useJUnit {
         excludeCategories 'com.cloudinary.test.TimeoutTest'
+        if (System.getProperty("CLOUDINARY_ACCOUNT_URL") == "") {
+            exclude '**/AccountApiTest.class'
+        }
     }
 }
 


### PR DESCRIPTION
This PR allows to ignore account provisioning tests when a corresponding environment is not available, thus reducing the number of false negative tests. 