### PR TITLE
Add folder decoupling support

### DIFF
--- a/cloudinary-core/src/main/java/com/cloudinary/Util.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Util.java
@@ -11,7 +11,7 @@ import java.util.*;
 public class Util {
     static final String[] BOOLEAN_UPLOAD_OPTIONS = new String[]{"backup", "exif", "faces", "colors", "image_metadata", "use_filename", "unique_filename",
             "eager_async", "invalidate", "discard_original_filename", "overwrite", "phash", "return_delete_token", "async", "quality_analysis", "cinemagraph_analysis",
-            "accessibility_analysis"};
+            "accessibility_analysis", "use_filename_as_display_name"};
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static final Map<String, Object> buildUploadParams(Map options) {
@@ -36,6 +36,9 @@ public class Util {
         params.put("moderation", options.get("moderation"));
         params.put("access_mode", (String) options.get("access_mode"));
         params.put("filename_override", (String) options.get("filename_override"));
+        params.put("public_id_prefix", (String) options.get("public_id_prefix"));
+        params.put("asset_folder", (String) options.get("asset_folder"));
+        params.put("display_name", (String) options.get("display_name"));
         
         Object responsive_breakpoints = options.get("responsive_breakpoints");
         if (responsive_breakpoints != null) {

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
@@ -794,4 +794,17 @@ abstract public class AbstractUploaderTest extends MockableTest {
 
         ids.add(id);
     }
+
+    @Test
+    public void testUploadFolderDecoupling() throws IOException {
+        Map result = cloudinary.uploader().upload(SRC_TEST_IMAGE, asMap(
+                "use_filename_as_display_name", true,
+                "public_id_prefix", "test_id_prefix",
+                "asset_folder", "asset_folder_test",
+                "display_name", "display_name_test",
+                "asset_folder", "folder_test"));
+        assertNotNull(result.get("asset_folder"));
+        assertNotNull(result.get("display_name"));
+        assertNotNull(result.get("asset_folder"));
+    }
 }

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
@@ -796,18 +796,17 @@ abstract public class AbstractUploaderTest extends MockableTest {
     }
 
     @Test
-    public void testUploadFolderDecoupling() throws IOException {
+    public void testUploadFolderDecoupling() {
+        //TODO: Need to build a unit testing infrastructure
         Map options = asMap(
                 "use_filename_as_display_name", true,
                 "public_id_prefix", "test_id_prefix",
                 "asset_folder", "asset_folder_test",
-                "display_name", "display_name_test",
-                "asset_folder", "folder_test");
-        assertNotNull(options.get("asset_folder"));
-        assertNotNull(options.get("display_name"));
-        assertNotNull(options.get("asset_folder"));
-        Map result = cloudinary.uploader().upload(SRC_TEST_IMAGE, options);
-        assertNotNull(result);
-
+                "display_name", "display_name_test");
+        Map uploadParams = Util.buildUploadParams(options);
+        Assert.assertEquals("test_id_prefix", uploadParams.get("public_id_prefix"));
+        Assert.assertEquals(true, uploadParams.get("use_filename_as_display_name"));
+        Assert.assertEquals("asset_folder_test", uploadParams.get("asset_folder"));
+        Assert.assertEquals("display_name_test", uploadParams.get("display_name"));
     }
 }

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
@@ -797,14 +797,17 @@ abstract public class AbstractUploaderTest extends MockableTest {
 
     @Test
     public void testUploadFolderDecoupling() throws IOException {
-        Map result = cloudinary.uploader().upload(SRC_TEST_IMAGE, asMap(
+        Map options = asMap(
                 "use_filename_as_display_name", true,
                 "public_id_prefix", "test_id_prefix",
                 "asset_folder", "asset_folder_test",
                 "display_name", "display_name_test",
-                "asset_folder", "folder_test"));
-        assertNotNull(result.get("asset_folder"));
-        assertNotNull(result.get("display_name"));
-        assertNotNull(result.get("asset_folder"));
+                "asset_folder", "folder_test");
+        assertNotNull(options.get("asset_folder"));
+        assertNotNull(options.get("display_name"));
+        assertNotNull(options.get("asset_folder"));
+        Map result = cloudinary.uploader().upload(SRC_TEST_IMAGE, options);
+        assertNotNull(result);
+
     }
 }


### PR DESCRIPTION
### Brief Summary of Changes
Add support to folder decoupling: `public_id_prefix`, `asset_folder`, `use_filename_as_display_name`, `display_name`

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [x] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
