### PR TITLE
Add use_asset_folder_as_public_id_prefix

### DIFF
--- a/cloudinary-core/src/main/java/com/cloudinary/Util.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Util.java
@@ -11,7 +11,7 @@ import java.util.*;
 public class Util {
     static final String[] BOOLEAN_UPLOAD_OPTIONS = new String[]{"backup", "exif", "faces", "colors", "image_metadata", "use_filename", "unique_filename",
             "eager_async", "invalidate", "discard_original_filename", "overwrite", "phash", "return_delete_token", "async", "quality_analysis", "cinemagraph_analysis",
-            "accessibility_analysis", "use_filename_as_display_name"};
+            "accessibility_analysis", "use_filename_as_display_name", "use_asset_folder_as_public_id_prefix"};
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static final Map<String, Object> buildUploadParams(Map options) {

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractApiTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractApiTest.java
@@ -769,7 +769,7 @@ abstract public class AbstractApiTest extends MockableTest {
         String[] tags = {"a", "b", "c"};
         Map context = ObjectUtils.asMap("a", "b", "c", "d");
         Map result = api.createUploadPreset(ObjectUtils.asMap("unsigned", true, "folder", "folder", "transformation", EXPLICIT_TRANSFORMATION, "tags", tags, "context",
-                context, "live", true));
+                context, "live", true, "use_asset_folder_as_public_id_prefix", true));
         String name = result.get("name").toString();
         Map preset = api.uploadPreset(name, ObjectUtils.emptyMap());
         assertEquals(preset.get("name"), name);
@@ -777,6 +777,7 @@ abstract public class AbstractApiTest extends MockableTest {
         Map settings = (Map) preset.get("settings");
         assertEquals(settings.get("folder"), "folder");
         assertEquals(settings.get("live"), Boolean.TRUE);
+        assertEquals(settings.get("use_asset_folder_as_public_id_prefix"), true);
         Map outTransformation = (Map) ((java.util.ArrayList) settings.get("transformation")).get(0);
         assertEquals(outTransformation.get("width"), 100);
         assertEquals(outTransformation.get("crop"), "scale");

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
@@ -801,6 +801,7 @@ abstract public class AbstractUploaderTest extends MockableTest {
 
     @Test
     public void testUploadFolderDecoupling() {
+        //TODO: Need to build a unit testing infrastructure
         Map options = asMap(
                 "use_filename_as_display_name", true,
                 "public_id_prefix", "test_id_prefix",

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
@@ -801,16 +801,18 @@ abstract public class AbstractUploaderTest extends MockableTest {
 
     @Test
     public void testUploadFolderDecoupling() {
-        //TODO: Need to build a unit testing infrastructure
         Map options = asMap(
                 "use_filename_as_display_name", true,
                 "public_id_prefix", "test_id_prefix",
                 "asset_folder", "asset_folder_test",
-                "display_name", "display_name_test");
+                "display_name", "display_name_test",
+                "use_asset_folder_as_public_id_prefix", true);
+
         Map uploadParams = Util.buildUploadParams(options);
         Assert.assertEquals("test_id_prefix", uploadParams.get("public_id_prefix"));
         Assert.assertEquals(true, uploadParams.get("use_filename_as_display_name"));
         Assert.assertEquals("asset_folder_test", uploadParams.get("asset_folder"));
         Assert.assertEquals("display_name_test", uploadParams.get("display_name"));
+        Assert.assertEquals(true, uploadParams.get("use_asset_folder_as_public_id_prefix"));
     }
 }


### PR DESCRIPTION
### Brief Summary of Changes
Add new parameter to upload params `use_asset_folder_as_public_id_prefix`
The parameter can be used to upload/explicit/rename an asset
The parameter can also be used when creating/listing/updating upload preset


#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [x] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
