### PR TITLE
Add support for `on_success` upload parameter

### DIFF
--- a/cloudinary-core/src/main/java/com/cloudinary/Util.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Util.java
@@ -39,7 +39,7 @@ public class Util {
         params.put("public_id_prefix", (String) options.get("public_id_prefix"));
         params.put("asset_folder", (String) options.get("asset_folder"));
         params.put("display_name", (String) options.get("display_name"));
-        
+        params.put("on_success", (String) options.get("on_success"));
         Object responsive_breakpoints = options.get("responsive_breakpoints");
         if (responsive_breakpoints != null) {
             params.put("responsive_breakpoints", JSONObject.wrap(responsive_breakpoints));

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
@@ -767,7 +767,7 @@ abstract public class AbstractUploaderTest extends MockableTest {
     public void testOnSuccessScript() throws Exception {
         String tags = "[\"autocaption\"" + ",\"" + SDK_TEST_TAG + "\",\"" + UPLOADER_TAG + "\"]";
         Map result = cloudinary.uploader().upload(SRC_TEST_IMAGE, asMap("on_success", "current_asset.update({tags:" + tags + "});"));
-        assertEquals(result.get("tags"), asArray(new String[]{"autocaption"}));
+        assertTrue(((List<String>)result.get("tags")).contains("autocaption"));
     }
 
     @Test

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
@@ -764,6 +764,12 @@ abstract public class AbstractUploaderTest extends MockableTest {
     }
 
     @Test
+    public void testOnSuccessScript() throws Exception {
+        Map result = cloudinary.uploader().upload(SRC_TEST_IMAGE, asMap("on_success", "current_asset.update({tags: [\"autocaption\"]});", "tags", Arrays.asList(SDK_TEST_TAG, UPLOADER_TAG)));
+        assertEquals(result.get("tags"), asArray(new String[]{"autocaption"}));
+    }
+
+    @Test
     public void testQualityAnalysis() throws IOException {
         Map result = cloudinary.uploader().upload(SRC_TEST_IMAGE, asMap("quality_analysis", true, "tags", Arrays.asList(SDK_TEST_TAG, UPLOADER_TAG)));
         assertNotNull(result.get("quality_analysis"));

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractUploaderTest.java
@@ -765,7 +765,8 @@ abstract public class AbstractUploaderTest extends MockableTest {
 
     @Test
     public void testOnSuccessScript() throws Exception {
-        Map result = cloudinary.uploader().upload(SRC_TEST_IMAGE, asMap("on_success", "current_asset.update({tags: [\"autocaption\"]});", "tags", Arrays.asList(SDK_TEST_TAG, UPLOADER_TAG)));
+        String tags = "[\"autocaption\"" + ",\"" + SDK_TEST_TAG + "\",\"" + UPLOADER_TAG + "\"]";
+        Map result = cloudinary.uploader().upload(SRC_TEST_IMAGE, asMap("on_success", "current_asset.update({tags:" + tags + "});"));
         assertEquals(result.get("tags"), asArray(new String[]{"autocaption"}));
     }
 


### PR DESCRIPTION
### Brief Summary of Changes
Add support for `on_success` upload parameter

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [x] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
