### PR TITLE
Modify installation section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,18 @@ The cloudinary_java library is available in [Maven Central](https://mvnrepositor
 ```xml
 <dependency>
     <groupId>com.cloudinary</groupId>
-    <artifactId>cloudinary-http44</artifactId>
+    <artifactId>cloudinary-http45</artifactId>
     <version>1.34.0</version>
 </dependency>
 ```
 
-Alternatively, download cloudinary_java from [here](https://repo1.maven.org/maven2/com/cloudinary/cloudinary-core/1.30.0/cloudinary-core-1.30.0.jar) and [here](https://repo1.maven.org/maven2/com/cloudinary/cloudinary-http44/1.30.0/cloudinary-http44-1.30.0.jar)
-and see [build.gradle](https://github.com/cloudinary/cloudinary_java/blob/master/cloudinary-http44/build.gradle) for library dependencies.
+Alternatively, download cloudinary_java from [here](https://repo1.maven.org/maven2/com/cloudinary/cloudinary-core/1.30.0/cloudinary-core-1.30.0.jar) and [here](https://repo1.maven.org/maven2/com/cloudinary/cloudinary-http45/1.30.0/cloudinary-http45-1.30.0.jar)
+and see [build.gradle](https://github.com/cloudinary/cloudinary_java/blob/master/cloudinary-http45/build.gradle) for library dependencies.
+
+Different variants of the cloudinary_java library based on previous versions of Apache HTTP library are available as well:
+* **cloudinary-http44** - Cloudinary Apache HTTP 4.4 Library
+* **cloudinary-http43** - Cloudinary Apache HTTP 4.3 Library
+* **cloudinary-http42** - Cloudinary Apache HTTP 4.2 Library
 
 ## Usage
 ### Setup


### PR DESCRIPTION
### Brief Summary of Changes
Apache HttpClient versions prior to version 4.5.13 are affected by https://nvd.nist.gov/vuln/detail/CVE-2020-13956 , so it makes sense to default the installation section of the README to cloudinary-http45 which doesn't have that vulnerability. Added another small section to make the user aware they can use different artifactId based on which apache http library they want to utilise.

#### What does this PR address?
- [X] Documentation
