### PR TITLE
Add missing display_name parameter to update resource

### DIFF
--- a/cloudinary-core/src/main/java/com/cloudinary/Util.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Util.java
@@ -166,6 +166,9 @@ public class Util {
         if (options.get("unique_display_name") != null) {
             params.put("unique_display_name", options.get("unique_display_name"));
         }
+        if (options.get("display_name") != null) {
+            params.put("display_name", options.get("display_name"));
+        }
         putObject("ocr", options, params);
         putObject("raw_convert", options, params);
         putObject("categorization", options, params);


### PR DESCRIPTION
As mentioned in https://cloudinary.com/documentation/admin_api#update_details_of_an_existing_resource, the `display_name` parameter is required to update the resource name, but the library does not use it and the name is not updated.

### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->
As mentioned in https://cloudinary.com/documentation/admin_api#update_details_of_an_existing_resource, the `display_name` parameter is required to update the resource name, but it is not included in this library. This change is to include that parameter.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
