### PR TITLE
Bump httpcore5 5.2.5 -> 5.3.5 to fix DoS vulnerability (VIDEO-20814)

### DIFF
--- a/cloudinary-http5/build.gradle
+++ b/cloudinary-http5/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compile project(':cloudinary-core')
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     api group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.3.1'
-    api group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.2.5'
+    api group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.3.5'
     testCompile project(':cloudinary-test-common')
     testCompile group: 'org.hamcrest', name: 'java-hamcrest', version: '2.0.0.0'
     testCompile group: 'pl.pragmatists', name: 'JUnitParams', version: '1.0.5'

--- a/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractStructuredMetadataTest.java
+++ b/cloudinary-test-common/src/main/java/com/cloudinary/test/AbstractStructuredMetadataTest.java
@@ -84,7 +84,7 @@ public abstract class AbstractStructuredMetadataTest extends MockableTest {
 
     @Test
     public void testFieldRestrictions() throws Exception {
-        StringMetadataField stringField = newFieldInstance("testCreateMetadata_3", true);
+        StringMetadataField stringField = newFieldInstance("testCreateMetadata_3", false);
         stringField.setRestrictions(new Restrictions().setReadOnlyUI());
 
         ApiResponse result = api.addMetadataField(stringField);


### PR DESCRIPTION


### Brief Summary of Changes
Fixes SNYK-JAVA-ORGAPACHEHTTPCOMPONENTSCORE5-15857052: incorrect stream accounting in httpcore5-h2 allows unbounded concurrent streams via rapid resets. Also aligns httpcore5 version with httpclient5 5.3.x release train.

Fix testFieldRestrictions: Cloudinary API now rejects fields with both mandatory and readonly_ui set; test only asserts readonly_ui so mandatory=false is correct.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
