### PR TITLE
Forward `metadata` param on signed uploads in `Util.buildUploadParams`

### DIFF
--- a/cloudinary-core/src/main/java/com/cloudinary/Util.java
+++ b/cloudinary-core/src/main/java/com/cloudinary/Util.java
@@ -75,6 +75,7 @@ public final class Util {
             params.put("similarity_search", (String) options.get("similarity_search"));
             params.put("auto_tagging", (String) options.get("auto_tagging"));
             params.put("access_control", (String) options.get("access_control"));
+            params.put("metadata", (String) options.get("metadata"));
         }
         return params;
     }

--- a/cloudinary-core/src/test/java/com/cloudinary/UtilTest.java
+++ b/cloudinary-core/src/test/java/com/cloudinary/UtilTest.java
@@ -159,4 +159,21 @@ public class UtilTest {
         assertEquals("bcde", StringUtils.removeStartingChars("aaaaaabcde", 'a'));
         assertEquals("bcdeaa", StringUtils.removeStartingChars("aaaaaabcdeaa", 'a'));
     }
+
+    @Test
+    public void testBuildUploadParamsForwardsMetadataWhenSigned() {
+        String signatureKey = "signature";
+        String timestampKey = "timestamp";
+        String metadataKey = "metadata";
+
+        Map<String, Object> params = Util.buildUploadParams(
+            ObjectUtils.asMap(
+                signatureKey, "abc-signature",
+                timestampKey, "1782744652",
+                metadataKey, "delete_date=2026-07-06"
+            )
+        );
+
+        assertEquals("delete_date=2026-07-06", params.get(metadataKey));
+    }
 }


### PR DESCRIPTION
### 🔍 Brief Summary of Changes

Hello there @const-cloudinary, it seems you are the person in charge taking care of the repository 💪  
Here is a little PR that hopefully solves and explain an issue we encountered lately with @vschoener

When an upload request carries a server-computed `signature`, `Util.buildUploadParams` takes a "pre-signed" branch that forwards only a fixed allow-list of write params. 

**🐛 Our issue:** `metadata` is not on the "allow-list" list, so it is silently dropped and never sent to Cloudinary that re-compute the signature against our backend:

```
401 Invalid Signature ... String to sign - 'asset_folder=...&timestamp=...&upload_preset=...'
```

> (Note `metadata` is absent from the string Cloudinary reconstructs.)

### Root cause

In `cloudinary-core/.../com/cloudinary/Util.java`, `buildUploadParams` only copies `metadata` via `processWriteParameters`, **which is only called if there are no signatures**. 

The `else` (signature-present) branch forwards `eager, transformation, headers, tags, face_coordinates, context, ocr, raw_convert, categorization, detection, similarity_search, auto_tagging, access_control` - but not `metadata`.

### Fix

Add `metadata` to the pre-signed pass-through branch, mirroring how `context` is already handled there (the value is already serialized, so it's passed through as-is).

### 📑 Note on SDK parity w/ 🍎

The iOS SDK does not filter params on the signed path ([CLDNetworkCoordinator.getSignedRequestParams](https://github.com/cloudinary/cloudinary_ios/blob/master/Cloudinary/Classes/Core/Network/CLDNetworkCoordinator.swift#L82) forwards the full param set), so a presigned upload including `metadata` already works on iOS. 

This change brings the Java/Android SDK in line (at least for the metadata).

ℹ️ With this changes we were able to fix our upload issue by making `cloudinary-android-core` a local patched module of `cloudinary-core`.

Many thanks for your time reviewing the PR 🙏

#### What does this PR address?
- [ ] GitHub issue
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes 
- [ ] No

#### ✅ Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.